### PR TITLE
Create documentation

### DIFF
--- a/docs/docs-nav.yml
+++ b/docs/docs-nav.yml
@@ -1,0 +1,6 @@
+# NOTE: The URLs need a trailing slash or the selected nav element
+#       won't be highlighted.
+  - title: Test Report Features
+    children:
+      - title: "How To"
+        url: /docs/how-to-test-reports/

--- a/docs/how-to-test-reports.adoc
+++ b/docs/how-to-test-reports.adoc
@@ -1,0 +1,7 @@
+:page-title: How to use Test Reports
+:page-description: Explains how to use test reports
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/docs/project-page.adoc
+++ b/docs/project-page.adoc
@@ -1,0 +1,9 @@
+---
+excerpt: 'Reports on tests. :)<br/> <small>Released on [GitHub](https://github.com/junit-pioneer/test-reports/releases), [JCenter](https://jcenter.bintray.com/org/junit-pioneer/test-reports/), and [Maven Central](https://mvnrepository.com/artifact/org.junit-pioneer/test-reports) under<br /><span class="coordinates">`org.junit-pioneer : test-reports : @tr:version`</span></small><br/><br/> {::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=junit-pioneer&repo=test-reports&type=watch&count=true&size=large&v=2" frameborder="0" scrolling="0" width="145px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=junit-pioneer&repo=test-reports&type=star&count=true&size=large" frameborder="0" scrolling="0" width="138px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=junit-pioneer&repo=test-reports&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="138px" height="30px"></iframe>{:/nomarkdown}'
+---
+:page-layout: single
+:page-permalink: /test-reports/
+:page-header: { overlay_image: {site-images}/test-reports-full.jpg, title_alignment: left }
+:page-title: Test Reports
+
+A description of the very cool Test Reports.


### PR DESCRIPTION
This is the first step to getting the documentation on the pioneer website. Once the files in here are filled with proper content and a first version was released, we can include it in the website project.

TODOs:

* write excerpt and text in `project-page.adoc`
* write at least one doc entry (potentially replacing `how-to-test-reports.adoc`) and link to it from `docs-nav.yml`

We also need a picture to represent Test Reports - is used [this one](https://unsplash.com/photos/AT77Q0Njnt0) but you may want to find something more suitable (pay attention to the license.)
