### PR TITLE
Update dependabot and dependencies (#22 / #23)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,21 @@
 version: 2
 
 updates:
-- package-ecosystem: gradle
-  directory: "/"
-  schedule:
-    interval: monthly
-  ignore:
-    - dependency-name: "org.junit.*"
-    - dependency-name: "org.junit-pioneer.*"
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: monthly
+    ignore:
+      - dependency-name: "org.junit.*"
+      - dependency-name: "org.junit-pioneer.*"
+    labels:
+      - "📖 theme: build"
+      - "🛸 3rd-party: Gradle"
 
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: monthly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    labels:
+      - "📖 theme: infrastructure"
+      - "🛸 3rd-party: Github Actions"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,12 +48,12 @@ dependencies {
 
 	testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-api")
 
-	testImplementation(group = "org.assertj", name = "assertj-core", version = "3.17.2")
-	testImplementation(group = "org.mockito", name = "mockito-core", version = "3.3.3")
+	testImplementation(group = "org.assertj", name = "assertj-core", version = "3.18.1")
+	testImplementation(group = "org.mockito", name = "mockito-core", version = "3.6.28")
 	testImplementation(group = "com.google.jimfs", name = "jimfs", version = "1.1")
 
-	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.12.1")
-	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-jul", version = "2.12.1")
+	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.14.0")
+	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-jul", version = "2.14.0")
 }
 
 spotless {


### PR DESCRIPTION
```
Update dependabot and dependencies (#22 / #23)

This updates dependabot to use our own labels.
Also the suggestest dependencies are updated.
This PR does the same updates as in the extension pack repository.

closes #22 
PR: #23

```